### PR TITLE
Fix Windows build

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -8,7 +8,7 @@ target_compile_features(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME}
-        OpenGL::OpenGL
+        OpenGL::GL
         glfw
         glad
         imgui-glfw-lib

--- a/external/external.cmake
+++ b/external/external.cmake
@@ -81,7 +81,7 @@ if(NOT imgui_POPULATED)
       ${imgui_SOURCE_DIR}/examples
   )
 
-  target_link_libraries(${IMGUI_LIB_NAME} OpenGL::OpenGL glad glfw)
+  target_link_libraries(${IMGUI_LIB_NAME} OpenGL::GL glad glfw)
 endif()
 
 #

--- a/lib/geom/CMakeLists.txt
+++ b/lib/geom/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(${PROJECT_NAME}
 )
 
 target_compile_features(${PROJECT_NAME}
-        PRIVATE
+        PUBLIC
         cxx_std_17
 )
 

--- a/lib/loader/CMakeLists.txt
+++ b/lib/loader/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(${PROJECT_NAME}
 )
 
 target_compile_features(${PROJECT_NAME}
-        PRIVATE
+        PUBLIC
             cxx_std_17
 )
 

--- a/lib/ogl/CMakeLists.txt
+++ b/lib/ogl/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(${PROJECT_NAME}
 )
 
 target_compile_features(${PROJECT_NAME}
-        PRIVATE
+        PUBLIC
             cxx_std_17
 )
 


### PR DESCRIPTION
* Make std_cxx_17 a public compile feature due to the use of nested
namespace definitions in headers.
* Link against OpenGL::GL instead of OpenGL::OpenGL to support targets
w/o support for GLVND.

See: https://cmake.org/cmake/help/latest/module/FindOpenGL.html#linux-specific

This commit fixes both the msys2/mingw-w64 build and the Visual Studio build.